### PR TITLE
Rename project as @bigtest/ink and add publish actions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,18 @@
+name: Preview
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish-previews:
+    name: Publish Preview Packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@v1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-releases:
+    name: Publish Releases
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish Releases
+      uses: thefrontside/actions/synchronize-with-npm@v1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ink",
+	"name": "@bigtest/ink",
 	"version": "2.7.1",
 	"description": "React for CLI",
 	"license": "MIT",


### PR DESCRIPTION
## Motivation

I'm starting to wire all of the Ink work that I've been doing into the [cli-mob branch of BigTest](https://github.com/thefrontside/bigtest/tree/cli-mob) that we started working on during the all-hands. 

I tried to add the [tm/regions](https://github.com/thefrontside/ink/tree/tm/regions) branch as a dependency but `ts-node`doesn't compile node_modules because [according to the creator](https://github.com/TypeStrong/ts-node/issues/155#issuecomment-237713489) of `ts-node`, "TypeScript libraries should be distributed in JavaScript with declarations enabled."

I need to publish a package that I can add as a dependency.

## Approach

Renamed project to @bigtest/ink and adding Frontside Preview & Release actions.
 