### PR TITLE
Switch publish branch to bigtest

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches:
-      - master
+      - bigtest
 
 jobs:
   publish-previews:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - bigtest
 
 jobs:
   publish-releases:


### PR DESCRIPTION
## Motivation

I'm going to be tracking ink#master for a while so I created a "bigtest" branch and made it the default branch. I'll use it as an integration branch for all changes that I need to keep BigTest development moving forward.

## Approach

Changed publishing previews and release from bigtest branch.